### PR TITLE
allowing cat to cope with parameters

### DIFF
--- a/modules/core/base/include/nt2/predicates/functions/ofsameheight.hpp
+++ b/modules/core/base/include/nt2/predicates/functions/ofsameheight.hpp
@@ -16,7 +16,7 @@
  * \defgroup core_is_equal is_equal
  *
  * \par Description
- * Returns true or false according a0 and a1 have same height.
+ * Returns true or false according a0 and a1  ... an have all the same height.
  *
  * \par Header file
  *
@@ -32,12 +32,12 @@
  * \code
  * namespace boost::simd
  * {
- *   template <class A0>
- *     bool ofsameheight(const A0 & a0);
+ *   template <class ...A0>
+ *     bool ofsameheight(const A0... & a0);
  * }
  * \endcode
  *
- * \param a0 the first parameter of ofsameheight
+ * \param a0 the pack parameter of ofsameheight
  *
  * \return a bool value
  *
@@ -67,6 +67,14 @@ namespace nt2
   }
 
   NT2_FUNCTION_IMPLEMENTATION(nt2::tag::ofsameheight_, ofsameheight, 2)
+
+
+  template <class T1, class T2, class... Args > bool
+  ofsameheight(const T1 & f, const T2 & s, const Args&... args)
+  {
+    if (!ofsameheight(f, s)) return false;
+    return ofsameheight(s, args...);
+  }
 }
 
 #endif

--- a/modules/core/base/include/nt2/predicates/functions/ofsamewidth.hpp
+++ b/modules/core/base/include/nt2/predicates/functions/ofsamewidth.hpp
@@ -15,8 +15,8 @@
  * \ingroup core
  * \defgroup core_is_equal is_equal
  *
- * \par Description
- * Returns true or false according a0 and a1 have same width.
+ * \par Description ... an
+ * Returns true or false according a0 and a1 ... an have all the same width.
  *
  * \par Header file
  *
@@ -30,12 +30,12 @@
  * \code
  * namespace boost::simd
  * {
- *   template <class A0>
- *     bool ofsamewidth(const A0 & a0);
+ *   template <class ...A0>
+ *     bool ofsamewidth(const A0... & a0);
  * }
  * \endcode
  *
- * \param a0 the first parameter of ofsamewidth
+ * \param a0 the pack parameter of ofsamewidth
  *
  * \return a bool value
  *
@@ -65,6 +65,13 @@ namespace nt2
   }
 
   NT2_FUNCTION_IMPLEMENTATION(nt2::tag::ofsamewidth_, ofsamewidth, 2)
+
+  template <class T1, class T2, class... Args > bool
+  ofsamewidth(const T1 & f, const T2 & s, const Args&... args)
+  {
+    if (!ofsamewidth(f, s)) return false;
+    return ofsamewidth(s, args...);
+  }
 }
 
 #endif

--- a/modules/core/container/table/include/nt2/predicates/functions/table/ofsameheight.hpp
+++ b/modules/core/container/table/include/nt2/predicates/functions/table/ofsameheight.hpp
@@ -29,6 +29,36 @@ namespace nt2 { namespace ext
       return height(a0) == height(a1);
     }
   };
+  BOOST_DISPATCH_IMPLEMENT  ( ofsameheight_, tag::cpu_
+                            , (A0)(A1)
+                            , ((ast_<A0, nt2::container::domain>))
+                              (scalar_<unspecified_<A1>>)
+                            )
+  {
+    typedef bool result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const A0& a0, const A1&) const
+    {
+      return height(a0) == 1;
+    }
+  };
+  BOOST_DISPATCH_IMPLEMENT  ( ofsameheight_, tag::cpu_
+                            , (A0)(A1)
+                            , (scalar_<unspecified_<A0>>)
+                              ((ast_<A1, nt2::container::domain>))
+                            )
+  {
+    typedef bool result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const A0&, const A1& a1) const
+    {
+      return height(a1) == 1;
+    }
+  };
+
+
 } }
 
 #endif

--- a/modules/core/container/table/include/nt2/predicates/functions/table/ofsamewidth.hpp
+++ b/modules/core/container/table/include/nt2/predicates/functions/table/ofsamewidth.hpp
@@ -29,6 +29,34 @@ namespace nt2 { namespace ext
       return width(a0) == width(a1);
     }
   };
+  BOOST_DISPATCH_IMPLEMENT  ( ofsamewidth_, tag::cpu_
+                            , (A0)(A1)
+                            , ((ast_<A0, nt2::container::domain>))
+                              (scalar_<unspecified_<A1>>)
+                            )
+  {
+    typedef bool result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const A0& a0, const A1&) const
+    {
+      return width(a0) == 1;
+    }
+  };
+  BOOST_DISPATCH_IMPLEMENT  ( ofsamewidth_, tag::cpu_
+                            , (A0)(A1)
+                            , (scalar_<unspecified_<A0>>)
+                              ((ast_<A1, nt2::container::domain>))
+                            )
+  {
+    typedef bool result_type;
+
+    BOOST_FORCEINLINE
+    result_type operator()(const A0&, const A1& a1) const
+    {
+      return width(a1) == 1;
+    }
+  };
 } }
 
 #endif

--- a/modules/core/container/table/unit/predicates/ofsameheight.cpp
+++ b/modules/core/container/table/unit/predicates/ofsameheight.cpp
@@ -24,3 +24,26 @@ NT2_TEST_CASE( container_ofsameheight )
   NT2_TEST( !nt2::ofsameheight( a, b) );
 
 }
+
+NT2_TEST_CASE( container_scalar_ofsameheight )
+{
+  using nt2::_;
+  float a = 4.0f;
+  nt2::table<float> b = nt2::ones(1, 3, nt2::meta::as_<float>());
+
+  NT2_TEST( nt2::ofsameheight( a, b) );
+  NT2_TEST( nt2::ofsameheight( b, a) );
+
+}
+
+NT2_TEST_CASE( container_multi_ofsameheight )
+{
+  using nt2::_;
+  nt2::table<float> a = nt2::ones(3, 3, nt2::meta::as_<float>());
+  nt2::table<float> b = nt2::ones(3, 4, nt2::meta::as_<float>());
+  nt2::table<float> c = nt2::ones(3, 5, nt2::meta::as_<float>());
+  nt2::table<float> d = nt2::ones(4, 5, nt2::meta::as_<float>());
+
+  NT2_TEST( nt2::ofsameheight( a, b, c) );
+  NT2_TEST( !nt2::ofsameheight( a, b, d) );
+}

--- a/modules/core/container/table/unit/predicates/ofsamewidth.cpp
+++ b/modules/core/container/table/unit/predicates/ofsamewidth.cpp
@@ -25,3 +25,25 @@ NT2_TEST_CASE( container )
   NT2_TEST( nt2::ofsamewidth( a, b) );
 
 }
+NT2_TEST_CASE( container_scalar_ofsamewidth )
+{
+  using nt2::_;
+  float a = 4.0f;
+  nt2::table<float> b = nt2::ones(1, 3, nt2::meta::as_<float>());
+
+  NT2_TEST( nt2::ofsamewidth( a, b) );
+  NT2_TEST( nt2::ofsamewidth( b, a) );
+
+}
+
+NT2_TEST_CASE( container_multi_ofsamewidth )
+{
+  using nt2::_;
+  nt2::table<float> a = nt2::ones(3, 3, nt2::meta::as_<float>());
+  nt2::table<float> b = nt2::ones(3, 4, nt2::meta::as_<float>());
+  nt2::table<float> c = nt2::ones(3, 5, nt2::meta::as_<float>());
+  nt2::table<float> d = nt2::ones(4, 5, nt2::meta::as_<float>());
+
+  NT2_TEST( nt2::ofsamewidth( a, b, c) );
+  NT2_TEST( !nt2::ofsamewidth( a, b, d) );
+}

--- a/modules/core/restructuring/include/nt2/core/functions/horzcat.hpp
+++ b/modules/core/restructuring/include/nt2/core/functions/horzcat.hpp
@@ -51,19 +51,21 @@ namespace nt2
     For every table expressions:
 
     @code
-    auto r = horzcat(a0,a1);
+    auto r = horzcat(a0,a1,..., an);
     @endcode
 
     is similar to:
 
     @code
-    auto r = cat(2, a0, a1);
+    auto r = cat(2, a0, a1, ... an);
     @endcode
 
     @see @funcref{vertcat}, @funcref{cat}
     @par alias: @c cath
     @param a0
     @param a1
+    ...
+    @param an
 
     @return an expression which eventually will evaluate to the result
   **/
@@ -76,6 +78,21 @@ namespace nt2
   NT2_FUNCTION_IMPLEMENTATION(nt2::tag::horzcat_, cath, 1)
   /// INTERNAL ONLY
   NT2_FUNCTION_IMPLEMENTATION(nt2::tag::horzcat_, cath, 2)
+
+  template <class T, class... Args >
+  auto horzcat(const T & f, const Args&... args)
+    -> decltype(cat(2, f, cat(2, args...)))
+  {
+    return cat(2, f, cat(2, args...));
+  }
+
+  template <class T, class... Args > auto cath(const T & f, const Args&... args)
+    ->  decltype(cat(2, f, cat(2, args...)))
+  {
+    return horzcat(f, args...);
+  }
+
+
 }
 
 #endif

--- a/modules/core/restructuring/include/nt2/core/functions/vertcat.hpp
+++ b/modules/core/restructuring/include/nt2/core/functions/vertcat.hpp
@@ -73,6 +73,22 @@ namespace nt2
   NT2_FUNCTION_IMPLEMENTATION(nt2::tag::vertcat_, catv, 1)
   /// INTERNAL ONLY
   NT2_FUNCTION_IMPLEMENTATION(nt2::tag::vertcat_, catv, 2)
+
+  template <class T, class... Args >
+  auto vertcat(const T & f, const Args&... args)
+    -> decltype(cat(1, f, cat(1, args...)))
+  {
+    return cat(1, f, cat(1, args...));
+  }
+
+  template <class T, class... Args >
+  auto cath(const T & f, const Args&... args)
+    ->  decltype(cat(1, f, cat(1, args...)))
+  {
+    return vertcat(f, args...);
+  }
+
+
 }
 
 #endif


### PR DESCRIPTION
this uses variadic templates to be able to call cat and others as

 auto r = catv( cath(a,b,c,d),cath(e,f,g,h),d,e));

ie cat functors are not limited to 2 params