### PR TITLE
Made prev/next_power_of_2 a generic function.

### DIFF
--- a/modules/boost/simd/sdk/include/boost/simd/sdk/next_power_of_2.hpp
+++ b/modules/boost/simd/sdk/include/boost/simd/sdk/next_power_of_2.hpp
@@ -11,8 +11,7 @@
 #define BOOST_SIMD_SDK_NEXT_POWER_OF_2_HPP_INCLUDED
 
 #include <boost/config.hpp>
-#include <boost/static_assert.hpp>
-#include <boost/type_traits/is_integral.hpp>
+#include <type_traits>
 
 namespace boost { namespace simd
 {
@@ -25,7 +24,7 @@ namespace boost { namespace simd
     For any given integral value @c n:
 
     @code
-    std::size_t r = next_power_of_2(n);
+    auto r = next_power_of_2(n);
     @endcode
 
     where @c r verifies:
@@ -45,7 +44,7 @@ namespace boost { namespace simd
     template < typename Int , int s >
     struct next_power_of_2_impl
     {
-      static BOOST_FORCEINLINE
+      BOOST_STATIC_CONSTEXPR BOOST_FORCEINLINE
       Int apply( Int n )
       {
         n = next_power_of_2_impl<Int,s/2>::apply(n);
@@ -56,7 +55,7 @@ namespace boost { namespace simd
     template < typename Int >
     struct next_power_of_2_impl<Int,1>
     {
-      static BOOST_FORCEINLINE
+      BOOST_STATIC_CONSTEXPR BOOST_FORCEINLINE
       Int apply( Int n )
       {
         return n;
@@ -67,11 +66,11 @@ namespace boost { namespace simd
 
 
   template < typename Int >
-  inline Int next_power_of_2( Int n )
+  BOOST_CONSTEXPR inline Int next_power_of_2( Int n )
   {
-    BOOST_STATIC_ASSERT( is_integral<Int>::value );
-    typedef  detail::next_power_of_2_impl< Int, sizeof(Int)*8 >  impl;
-    return  impl::apply(--n) + Int(1);
+    static_assert( std::is_integral<Int>::value , "Int must be an integral type." );
+    using impl = detail::next_power_of_2_impl< Int, sizeof(Int)*8 >;
+    return  impl::apply(--n) + Int{1};
   }
 
 

--- a/modules/boost/simd/sdk/include/boost/simd/sdk/next_power_of_2.hpp
+++ b/modules/boost/simd/sdk/include/boost/simd/sdk/next_power_of_2.hpp
@@ -11,6 +11,8 @@
 #define BOOST_SIMD_SDK_NEXT_POWER_OF_2_HPP_INCLUDED
 
 #include <boost/config.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_integral.hpp>
 
 namespace boost { namespace simd
 {
@@ -67,6 +69,7 @@ namespace boost { namespace simd
   template < typename Int >
   inline Int next_power_of_2( Int n )
   {
+    BOOST_STATIC_ASSERT( is_integral<Int>::value );
     typedef  detail::next_power_of_2_impl< Int, sizeof(Int)*8 >  impl;
     return  impl::apply(--n) + Int(1);
   }

--- a/modules/boost/simd/sdk/include/boost/simd/sdk/next_power_of_2.hpp
+++ b/modules/boost/simd/sdk/include/boost/simd/sdk/next_power_of_2.hpp
@@ -10,10 +10,11 @@
 #ifndef BOOST_SIMD_SDK_NEXT_POWER_OF_2_HPP_INCLUDED
 #define BOOST_SIMD_SDK_NEXT_POWER_OF_2_HPP_INCLUDED
 
+#include <boost/config.hpp>
+
 namespace boost { namespace simd
 {
-
-/*!
+  /*!
     @brief Evaluates next power of 2
 
     Computes the power of two greater or equal to any given integral value @c n.
@@ -33,18 +34,42 @@ namespace boost { namespace simd
 
     @param n Integral value.
 
-    @return An unsigned integral value.
+    @return Integral value of same type as n.
   **/
-  inline std::size_t next_power_of_2(std::size_t n)
+
+  namespace detail
+  {
+
+    template < typename Int , int s >
+    struct next_power_of_2_impl
     {
-      std::size_t x0    = n-1;
-      std::size_t x1    = x0 | (x0 >>  1);
-      std::size_t x2    = x1 | (x1 >>  2);
-      std::size_t x3    = x2 | (x2 >>  4);
-      std::size_t x4    = x3 | (x3 >>  8);
-      std::size_t x5    = x4 | (x4 >> 16);
-      return x5 + 1;
-    }
+      static BOOST_FORCEINLINE
+      Int apply( Int n )
+      {
+        n = next_power_of_2_impl<Int,s/2>::apply(n);
+        return n | (n >> s/2);
+      }
+    };
+
+    template < typename Int >
+    struct next_power_of_2_impl<Int,1>
+    {
+      static BOOST_FORCEINLINE
+      Int apply( Int n )
+      {
+        return n;
+      }
+    };
+
+  }
+
+
+  template < typename Int >
+  inline Int next_power_of_2( Int n )
+  {
+    typedef  detail::next_power_of_2_impl< Int, sizeof(Int)*8 >  impl;
+    return  impl::apply(--n) + Int(1);
+  }
 
 
 } }

--- a/modules/boost/simd/sdk/include/boost/simd/sdk/prev_power_of_2.hpp
+++ b/modules/boost/simd/sdk/include/boost/simd/sdk/prev_power_of_2.hpp
@@ -39,6 +39,7 @@ namespace boost { namespace simd
   template < typename Int >
   inline Int prev_power_of_2( Int n )
   {
+    BOOST_STATIC_ASSERT( is_integral<Int>::value );
     typedef  detail::next_power_of_2_impl< Int, sizeof(Int)*8 >  impl;
     return  (n == 0) ? Int(0) : (impl::apply(n) >> 1) + Int(1);
   }

--- a/modules/boost/simd/sdk/include/boost/simd/sdk/prev_power_of_2.hpp
+++ b/modules/boost/simd/sdk/include/boost/simd/sdk/prev_power_of_2.hpp
@@ -10,6 +10,8 @@
 #ifndef BOOST_SIMD_SDK_PREV_POWER_OF_2_HPP_INCLUDED
 #define BOOST_SIMD_SDK_PREV_POWER_OF_2_HPP_INCLUDED
 
+#include "next_power_of_2.hpp"
+
 namespace boost { namespace simd
 {
   /*!
@@ -32,19 +34,13 @@ namespace boost { namespace simd
 
     @param n Integral value.
 
-    @return An unsigned integral value.
+    @return Integral value of same type as n.
   **/
-  inline std::size_t prev_power_of_2(std::size_t n)
+  template < typename Int >
+  inline Int prev_power_of_2( Int n )
   {
-    if(n==0) return 0;
-
-    std::size_t x0    = n;
-    std::size_t x1    = x0 | (x0 >>  1);
-    std::size_t x2    = x1 | (x1 >>  2);
-    std::size_t x3    = x2 | (x2 >>  4);
-    std::size_t x4    = x3 | (x3 >>  8);
-    std::size_t x5    = x4 | (x4 >> 16);
-    return (x5 >> 1) + 1;
+    typedef  detail::next_power_of_2_impl< Int, sizeof(Int)*8 >  impl;
+    return  (n == 0) ? Int(0) : (impl::apply(n) >> 1) + Int(1);
   }
 } }
 

--- a/modules/boost/simd/sdk/include/boost/simd/sdk/prev_power_of_2.hpp
+++ b/modules/boost/simd/sdk/include/boost/simd/sdk/prev_power_of_2.hpp
@@ -23,7 +23,7 @@ namespace boost { namespace simd
     For any given integral value @c n:
 
     @code
-    std::size_t r = prev_power_of_2(n);
+    auto r = prev_power_of_2(n);
     @endcode
 
     where @c r verifies:
@@ -37,11 +37,11 @@ namespace boost { namespace simd
     @return Integral value of same type as n.
   **/
   template < typename Int >
-  inline Int prev_power_of_2( Int n )
+  inline BOOST_CONSTEXPR Int prev_power_of_2( Int n )
   {
-    BOOST_STATIC_ASSERT( is_integral<Int>::value );
-    typedef  detail::next_power_of_2_impl< Int, sizeof(Int)*8 >  impl;
-    return  (n == 0) ? Int(0) : (impl::apply(n) >> 1) + Int(1);
+    static_assert( std::is_integral<Int>::value , "Int must be an integral type." );
+    using impl = detail::next_power_of_2_impl< Int, sizeof(Int)*8 >;
+    return  (n == 0) ? Int{0} : (impl::apply(n) >> 1) + Int{1};
   }
 } }
 


### PR DESCRIPTION
Made `prev_power_of_2`and `next_power_of_2` generic functions that works with all integral types.
This is done to…
 * get rid of warnings, or to avoid unnecessary explicit casts to `size_t` when using this function,
 * compute only necessary shifts, depending on the size of the integral type.
