### PR TITLE
fix asm clobber spec for cpuid in cpuidex

### DIFF
--- a/modules/boost/simd/config/include/boost/simd/sdk/config/details/detector/cpuid.hpp
+++ b/modules/boost/simd/config/include/boost/simd/sdk/config/details/detector/cpuid.hpp
@@ -51,7 +51,7 @@ namespace boost { namespace simd { namespace config { namespace x86
     : "=a"(CPUInfo[eax]), "=r"(CPUInfo[ebx])
     , "=c"(CPUInfo[ecx]), "=d"(CPUInfo[edx])
     : "a"(InfoType)
-    : "cc"
+    : "cc", "ebx"
     );
 #endif
 
@@ -90,7 +90,7 @@ namespace boost { namespace simd { namespace config { namespace x86
     : "=a"(CPUInfo[eax]), "=r"(CPUInfo[ebx])
     , "=c"(CPUInfo[ecx]), "=d"(CPUInfo[edx])
     : "a"(InfoType), "c" (ECXValue)
-    : "cc"
+    : "cc", "ebx"
     );
 #endif
 


### PR DESCRIPTION
In function `cpuidex`, the inline assembly for "cpuid" is using %ebx , but does not tell this fact to the compiler. Additionally it lets the compiler pick a register location "=r" for the second output operand "%1". 
From my understanding the compiler is allowed to pick %ebx for "%1", but this causes a wrong result in `CPUInfo[ebx]`

This is fixed by adding %ebx to the  globber list.
(If you need a quick refresher on the asm syntax: https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html )

## Effect of the bug
Before the fix, some versions of clang choose to place the second output operand into %ebx, hence the following minimal program:
```
int main(int argc, const char * argv[])
{
    return  boost::simd::is_supported<boost::simd::tag::avx2_>();        
}
```
would call cpuid like this (with clang 6.1.0 and -O2):
```
    0x2c9b <+187>: movl   %edi, %esi
    0x2c9d <+189>: movl   $0x7, %eax
    0x2ca2 <+194>: xorl   %ecx, %ecx
    0x2ca4 <+196>: pushl  %ebx
->  0x2ca5 <+197>: cpuid  
    0x2ca7 <+199>: movl   %ebx, %ebx
    0x2ca9 <+201>: popl   %ebx
    0x2caa <+202>: xorl   %ecx, %ecx
    0x2cac <+204>: testb  $0x20, %bl
```
Note that `testb` does **not** test the %ebx value returned by cpuid, but some random value that was in %ebx before that snippet was executed. 
_Side note: The presence of AVX2 is detected by testing the %ebx returned by `cpuid(EAX=7)` against 0x20_

As a result, the minimal program may erroneously detected avx2 support. 

For comparison, here is the same snippet with different compile settings (clang 6.1.0 and -O1):
```
    0x2c8d <+189>: movl   $0x7, %eax
    0x2c92 <+194>: xorl   %ecx, %ecx
    0x2c94 <+196>: pushl  %ebx
->  0x2c95 <+197>: cpuid  
    0x2c97 <+199>: movl   %ebx, %esi
    0x2c99 <+201>: popl   %ebx
    0x2c9a <+202>: xorl   %ecx, %ecx
    0x2c9c <+204>: movl   %esi, %eax
    0x2c9e <+206>: testb  $0x20, %al
```
Here, testb does correctly test the %ebx value returned by cpuid
